### PR TITLE
Fix Newline Character Issue in pipeline.py for Windows Compatibility

### DIFF
--- a/laktory/resourcesengines/pulumi/pipeline.py
+++ b/laktory/resourcesengines/pulumi/pipeline.py
@@ -67,7 +67,7 @@ class PulumiPipeline(PulumiResourcesEngine):
         d = pipeline.model_dump(exclude_none=True)
         d = pipeline.inject_vars(d)
         s = json.dumps(d, indent=4)
-        with open(source, "w") as fp:
+        with open(source, "w", newline="\n") as fp:
             fp.write(s)
         filepath = f"{settings.workspace_laktory_root}pipelines/{pipeline.name}.json"
         self.workspace_file = databricks.WorkspaceFile(


### PR DESCRIPTION
This Pull Request addresses an issue where the newline character handling was causing discrepancies when the package was used on Windows. The problem was due to the difference in newline characters between Unix-based and Windows systems (\n vs \r\n).

This was achieved by explicitly setting the newline parameter to "\n" in the open() function when writing to the temp file.