### PR TITLE
Fixing JobTaskSQLTask, to make query optional & adding source to JobTaskSqlTaskFile

### DIFF
--- a/laktory/models/resources/databricks/job.py
+++ b/laktory/models/resources/databricks/job.py
@@ -375,9 +375,15 @@ class JobTaskSqlTaskFile(BaseModel):
     ----------
     path:
         SQL filepath
+    source:
+        Location type of the notebook, can only be WORKSPACE or GIT. When set to WORKSPACE, the notebook will be
+        retrieved from the local Databricks workspace. When set to GIT, the notebook will be retrieved from a Git
+        repository defined in git_source. If the value is empty, the task will use GIT if git_source is defined and
+        WORKSPACE otherwise.        
     """
 
     path: str = None
+    source: Literal["WORKSPACE", "GIT"] = None
 
 
 class JobTaskSQLTask(BaseModel):
@@ -404,7 +410,7 @@ class JobTaskSQLTask(BaseModel):
     dashboard: JobTaskSqlTaskDashboard = None
     file: JobTaskSqlTaskFile = None
     parameters: dict[str, Any] = None
-    query: JobTaskSqlTaskQuery
+    query: JobTaskSqlTaskQuery = None
     warehouse_id: str = None
 
 


### PR DESCRIPTION
JobTaskSQLTask needs to have `query` as optional, as it's not a required field if a user specifies a file. 

Also updated the `JobTaskSqlTaskFile` to add `source` attribute to allow one to specify whether the file is in workspace or git.