### PR TITLE
Fix for warehouse tags when deploying via terraform

### DIFF
--- a/laktory/models/resources/databricks/warehouse.py
+++ b/laktory/models/resources/databricks/warehouse.py
@@ -37,7 +37,12 @@ class WarehouseTags(BaseModel):
     """
 
     custom_tags: list[WarehouseCustomTag] = []
-
+    
+    @property
+    def singularizations(self) -> dict[str, str]:
+        return {
+            "custom_tags": "custom_tags",
+        }
 
 class WarehouseLookup(ResourceLookup):
     """


### PR DESCRIPTION
See #283 - this fixes the issue by modifying `WarehouseTags`, making sure `custom_tags` property is not singularized.