### PR TITLE
Fix for job tasks to be sorted by task kay alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Singularized attribute names in `JobEmailNotifications` for Terraform [[#276](https://github.com/okube-ai/laktory/issues/276)]
 * Added missing `source` attribute in `JobTaskSqlTaskFile` [[#275](https://github.com/okube-ai/laktory/issues/275)]
 ### Updated
+* `Job` to automatically alphabetically sort `tasks` [[#286](https://github.com/okube-ai/laktory/issues/286)]
 * `Job` now supports `description` [[#277](https://github.com/okube-ai/laktory/issues/277)]
 * `JobTaskNotebookTask` now allows `warehouse_id` for compute [[#265](https://github.com/okube-ai/laktory/issues/265)]
 * `JobTaskSQLTask` updated to support `null` for queries [[#274](https://github.com/okube-ai/laktory/issues/274)]

--- a/laktory/models/resources/databricks/job.py
+++ b/laktory/models/resources/databricks/job.py
@@ -1,7 +1,7 @@
 from typing import Any
 from typing import Literal
 from typing import Union
-from pydantic import model_validator
+from pydantic import field_validator, model_validator
 from pydantic import Field
 from laktory._settings import settings
 from laktory.models.basemodel import BaseModel
@@ -862,3 +862,8 @@ class Job(BaseModel, PulumiResource, TerraformResource):
             d[k] = _clusters
 
         return d
+
+    @field_validator('tasks')
+    @classmethod
+    def sort_tasks(cls, v: list[JobTask]) -> list[JobTask]:
+        return sorted(v, key=lambda task: task.task_key)

--- a/laktory/models/resources/databricks/job.py
+++ b/laktory/models/resources/databricks/job.py
@@ -2,6 +2,7 @@ from typing import Any
 from typing import Literal
 from typing import Union
 from pydantic import field_validator, model_validator
+
 from pydantic import Field
 from laktory._settings import settings
 from laktory.models.basemodel import BaseModel
@@ -754,7 +755,11 @@ class Job(BaseModel, PulumiResource, TerraformResource):
     timeout_seconds: int = None
     trigger: JobTrigger = None
     webhook_notifications: JobWebhookNotifications = None
-
+    @field_validator('tasks')
+    @classmethod
+    def sort_tasks(cls, v: list[JobTask]) -> list[JobTask]:
+        return sorted(v, key=lambda task: task.task_key)
+    
     # ----------------------------------------------------------------------- #
     # Resource Properties                                                     #
     # ----------------------------------------------------------------------- #
@@ -862,8 +867,3 @@ class Job(BaseModel, PulumiResource, TerraformResource):
             d[k] = _clusters
 
         return d
-
-    @field_validator('tasks')
-    @classmethod
-    def sort_tasks(cls, v: list[JobTask]) -> list[JobTask]:
-        return sorted(v, key=lambda task: task.task_key)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,5 +1,6 @@
 from laktory.models.resources.databricks import Job
 
+
 job = Job(
     name="job-stock-prices",
     clusters=[
@@ -11,13 +12,6 @@ job = Job(
     ],
     tasks=[
         {
-            "job_cluster_key": "main",
-            "notebook_task": {
-                "notebook_path": "job/ingest_stock_prices",
-            },
-            "task_key": "ingestion",
-        },
-        {
             "depends_ons": [{"task_key": "ingestion"}],
             "pipeline_task": {"pipeline_id": "${resources.pl-spark-dlt.id}"},
             "task_key": "pipeline",
@@ -28,6 +22,13 @@ job = Job(
                 "query": {"query_id": "456"},
                 "warehouse_id": "123",
             },
+        },
+        {
+            "job_cluster_key": "main",
+            "notebook_task": {
+                "notebook_path": "job/ingest_stock_prices",
+            },
+            "task_key": "ingestion",
         },
     ],
     email_notifications={


### PR DESCRIPTION
Fix for #286 - adding a method in `Job` class that sorts its `tasks` by `task_key` whenever the class is serialized. This will ensure that when no job task's have been changed that terraform doesn't think an update is needed.