### PR TITLE
Fix for terraform resource type for storage credential

### DIFF
--- a/laktory/models/resources/databricks/storagecredential.py
+++ b/laktory/models/resources/databricks/storagecredential.py
@@ -226,7 +226,7 @@ class StorageCredential(BaseModel, PulumiResource, TerraformResource):
 
     @property
     def terraform_resource_type(self) -> str:
-        return "databricks_metastore_data_access"
+        return "databricks_storage_credential"
 
     @property
     def terraform_excludes(self) -> Union[list[str], dict[str, bool]]:


### PR DESCRIPTION
Was using the incorrect `databricks_metastore_data_access` terraform resource type instead of `databricks_storage_credential`