### PR TITLE
Fix/411 intellisense type return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Fixed
 * n/a
 ### Updated
-* n/a
+* Typing on the `BaseModel.model_validate_yaml` and the `BaseModel.model_validate_json_file` functions to have the typing on the arguments to provide correct intellisense for return typing of `Model`. [[#411](https://github.com/okube-ai/laktory/issues/411)]
 ### Breaking changes
 * n/a
 

--- a/laktory/models/basemodel.py
+++ b/laktory/models/basemodel.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from typing import Any
 from typing import TextIO
+from typing import Type
 from typing import TypeVar
 from typing import Union
 from typing import get_args
@@ -175,7 +176,7 @@ class BaseModel(_BaseModel, metaclass=ModelMetaclass):
     # ----------------------------------------------------------------------- #
 
     @classmethod
-    def model_validate_yaml(cls, fp: TextIO) -> Model:
+    def model_validate_yaml(cls: Type[Model], fp: TextIO) -> Model:
         """
         Load model from yaml file object using laktory.yaml.RecursiveLoader. Supports
         reference to external yaml and sql files using `!use`, `!extend` and `!update` tags.
@@ -232,7 +233,7 @@ class BaseModel(_BaseModel, metaclass=ModelMetaclass):
         return yaml.dump(self.model_dump(*args, **kwargs))
 
     @classmethod
-    def model_validate_json_file(cls, fp: TextIO) -> Model:
+    def model_validate_json_file(cls: Type[Model], fp: TextIO) -> Model:
         """
         Load model from json file object
 


### PR DESCRIPTION
Fix: Improve IntelliSense type inference for BaseModel

This PR updates the return type annotation for the `model_validate_yaml()` and the `model_validate_json_file()` method(s) to improve IntelliSense support. By specifying the `Type[Model]` is the class, developers using IDEs will benefit from better autocompletion and type checking when chaining method calls. No runtime behavior is affected.