### PR TITLE
Fix broken depends_on on LAKEFLOW_JOB config-file Permissions resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 * n/a
 ### Fixed
-* n/a
+* `depends_on` on a LAKEFLOW_JOB pipeline's auto-generated config-file `Permissions` resource pointing at a nonexistent resource when `settings.workspace_root: "user_root"` is used, causing `terraform plan` to fail [[#629](https://github.com/okube-ai/laktory/issues/629)]
 ### Updated
 * n/a
 ### Breaking changes

--- a/laktory/models/stacks/stack.py
+++ b/laktory/models/stacks/stack.py
@@ -115,6 +115,12 @@ def _resolve_databricks_provider_and_username(env):
     if db_provider is None:
         return None, None, None
 
+    # Called before the stack-wide `inject_vars()` pass (so that resolving
+    # `workspace_root: "user_root"` doesn't itself depend on it - see
+    # `Stack._resolve_user_root`), so credentials may still be raw
+    # `${vars.x}` templates. Resolve them on this provider alone.
+    db_provider = db_provider.inject_vars(vars=env.variables)
+
     wc = db_provider.workspace_client
     username = wc.current_user.me().user_name
     return db_provider, wc, username
@@ -611,13 +617,20 @@ class Stack(BaseModel):
         if inject_vars:
             if vars:
                 env = env.model_copy(update={"variables": {**env.variables, **vars}})
-            env = env.inject_vars()
             # Gated on `inject_vars` (not just run unconditionally) because
             # `to_terraform()` calls `env.build(env_name=None, inject_vars=False)`
             # internally on an already-resolved `env` - that internal call must
             # not re-run this with the wrong (None) env_name; to_terraform()
             # resolves it separately, beforehand, with its own correct env_name.
+            #
+            # Must run before `env.inject_vars()`: that call also caches
+            # `core_resources` (and any `depends_on` baked into it) on every
+            # resource in the stack, so resolving `workspace_root: "user_root"`
+            # afterward would leave resource names computed from the
+            # not-yet-resolved root frozen in already-cached `depends_on`
+            # entries, out of sync with the final resource names.
             self._resolve_user_root(env, env_name)
+            env = env.inject_vars()
 
         if env.resources is None:
             return
@@ -771,10 +784,11 @@ class Stack(BaseModel):
         env = self.get_env(env_name=env_name)
         if vars:
             env = env.model_copy(update={"variables": {**env.variables, **vars}})
-        env = env.inject_vars()
+        # Must run before `env.inject_vars()` - see the comment in `build()`.
         _resolved_provider, _resolved_wc, _resolved_username = self._resolve_user_root(
             env, env_name
         )
+        env = env.inject_vars()
         env.build(env_name=None, inject_vars=False)
 
         # Providers

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import pytest
@@ -1060,3 +1061,68 @@ def test_workspace_root_user_root_combined_with_state_backend_single_lookup(
         "/Users/user@test.com/.laktory/my-stack/dev/state/terraform.tfstate"
     )
     mock_wc.current_user.me.assert_called_once()
+
+
+def test_workspace_root_user_root_lakeflow_job_permissions_depends_on(monkeypatch):
+    """Regression for #629: a LAKEFLOW_JOB pipeline's auto-generated config-file
+    `Permissions` resource must `depends_on` the actual `databricks_workspace_file`
+    resource name, even when `settings.workspace_root: "user_root"` is resolved
+    (the resolved root wasn't yet known when the `Permissions` resource's
+    `depends_on` was first computed and cached)."""
+    from unittest.mock import MagicMock
+    from unittest.mock import PropertyMock
+    from unittest.mock import patch
+
+    from laktory.models.resources.providers.databricksprovider import DatabricksProvider
+
+    monkeypatch.setattr(settings, "workspace_root", settings.workspace_root)
+
+    mock_wc = MagicMock()
+    mock_wc.current_user.me.return_value.user_name = "user@test.com"
+
+    pl = models.Pipeline(
+        name="pl-job",
+        nodes=[
+            {
+                "name": "brz",
+                "sources": [{"format": "JSON", "path": "/brz_source/"}],
+                "sinks": [
+                    {"format": "PARQUET", "mode": "APPEND", "path": "/brz_sink/"}
+                ],
+            },
+        ],
+        orchestrator={
+            "type": "LAKEFLOW_JOB",
+            "name": "pl-job",
+            "serverless_environment_version": "5",
+        },
+    )
+
+    with patch.object(
+        DatabricksProvider, "workspace_client", new_callable=PropertyMock
+    ) as mock_prop:
+        mock_prop.return_value = mock_wc
+
+        stack = models.Stack(
+            name="my-stack",
+            environments={"dev": {"variables": {}}},
+            resources={
+                "providers": {"databricks": _DB_PROVIDER},
+                "pipelines": {"pl-job": pl.model_dump(exclude_unset=True)},
+            },
+            settings={"workspace_root": "user_root"},
+        )
+        d = stack.to_terraform(env_name="dev").model_dump()
+
+    resource_names = {rname for bodies in d["resource"].values() for rname in bodies}
+    perms = d["resource"]["databricks_permissions"]
+    assert len(perms) == 1
+    depends_on = next(iter(perms.values()))["depends_on"]
+    assert len(depends_on) == 1
+    # A resolved `depends_on` is rewritten to Terraform's native `type.name`
+    # reference; an unresolved one is left as the raw `${resources.name}`
+    # placeholder - either way, `name` must be a real resource.
+    dep = depends_on[0]
+    m = re.match(r"^\$\{resources\.([^}]+)\}$", dep)
+    dep_name = m.group(1) if m else dep.split(".", 1)[1]
+    assert dep_name in resource_names


### PR DESCRIPTION
## Summary
- Fixes #629: every `LAKEFLOW_JOB` pipeline's auto-generated config-file `Permissions` resource had a `depends_on` entry pointing at a nonexistent resource whenever `settings.workspace_root: "user_root"` was used, causing `terraform plan` to fail.
- Root cause: `Stack.to_terraform()`/`Stack.build()` called `env.inject_vars()` before `Stack._resolve_user_root()`. `inject_vars()` recursively caches each resource's `core_resources` (baking `depends_on` into it) using the not-yet-resolved `workspace_root`; the real resource name is computed later, after `workspace_root` is resolved, so the two diverge.
- Fix: resolve `workspace_root: "user_root"` before `env.inject_vars()` runs in both methods. Since the Databricks provider's credentials may still be templated (`${vars.x}`) at that point, `_resolve_databricks_provider_and_username()` now resolves vars on the discovered provider before using it for the live SDK lookup.

## Test plan
- [x] `uv run pytest tests/test_stack.py tests/pipeline/orchestrators/test_orchestrator_lakeflow_job.py -q` - all passing, including a new regression test that fails on the pre-fix code
- [x] Full suite (`uv run pytest -m "not databricks_connect" --cov=laktory tests`) - 927 passed, 1 failed (`test_update_data_profiling_configs_skips_when_explicitly_unmanaged`, pre-existing on `main`, environment-only: missing Databricks credentials), 77 skipped, 4 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yxhULMgENEBq5Er7ot6zm