### PR TITLE
Fix workspace_root resolution in LAKEFLOW_JOB config; add ${current_user.x}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,12 @@
 
 ## [0.12.5] - Unreleased
 ### Added
-* n/a
+* `${current_user.X}` variable namespace (currently `user_name`) exposing the live Databricks identity resolved via the SDK, mirroring `${settings.X}`. See [Variables](https://www.laktory.ai/concepts/variables/#current-user)
 ### Fixed
 * `inject_vars()` no longer crashes with a Pydantic `frozen_field` error when a frozen field (e.g. a data source's `type:` literal, such as `type: CUSTOM` on `CustomDataSource`) is explicitly set in YAML/code [[#628](https://github.com/okube-ai/laktory/issues/628)]
 * `depends_on` on a LAKEFLOW_JOB pipeline's auto-generated config-file `Permissions` resource pointing at a nonexistent resource when `settings.workspace_root: "user_root"` is used, causing `terraform plan` to fail [[#629](https://github.com/okube-ai/laktory/issues/629)]
-### Updated
-* n/a
-### Breaking changes
-* n/a
+* A `LAKEFLOW_JOB` or `LAKEFLOW_DECLARATIVE_PIPELINE` pipeline's own job/config definition (task `filepath`, dependency/library paths, `config_filepath`) baked in the raw, unresolved `settings.workspace_root` instead of the `"user_root"`-resolved value, causing the deployed job to fail with `FileNotFoundError` / library-install errors [[#630](https://github.com/okube-ai/laktory/issues/630)]
+
 
 ## [0.12.4] - 2026-08-28
 ### Added

--- a/docs/concepts/variables.md
+++ b/docs/concepts/variables.md
@@ -5,7 +5,7 @@ Laktory uses three distinct mechanisms to make declarations dynamic. They share 
 
 | Mechanism | Syntax | Resolved | Valid in |
 |-----------|--------|----------|----------|
-| **Variable** | `${vars.X}` · `${resources.X.id}` · `${settings.X}` | Config / deployment time | Any model field |
+| **Variable** | `${vars.X}` · `${resources.X.id}` · `${settings.X}` · `${current_user.X}` | Config / deployment time | Any model field |
 | **Expression** | `${{ python expr }}` | Config / deployment time | Any model field |
 | **Reference** | `{df}` · `{sources.X}` · `{nodes.X}` | Execution time | Transformer nodes only |
 
@@ -160,6 +160,24 @@ A settings field cannot reference a sibling settings field in the same block (e.
 
 For what `settings.workspace_root` actually controls, its default, and how to auto-scope it (and Terraform state) to your own user/stack/environment with almost no configuration, see [Workspace Root](workspaceroot.md).
 
+### Current User
+
+The `current_user.*` namespace exposes your live Databricks identity - currently just `user_name` - resolved via the Databricks SDK against the `DatabricksProvider` in your stack:
+
+```yaml title="stack.yaml"
+resources:
+  providers:
+    databricks: {}
+  databricks_workspacetrees:
+    app:
+      source: ./app/
+      path: /Users/${current_user.user_name}/app
+```
+
+Unlike `settings.*`, `current_user.*` isn't backed by a stack config field - it's resolved lazily, only when `${current_user.X}` is actually referenced somewhere in the stack, via one live SDK call (`workspace_client.current_user.me()`). A stack that never references it makes no network call for it. Referencing it without a `DatabricksProvider` in the stack raises a clear error rather than silently leaving the template unresolved.
+
+If the stack also uses `settings.workspace_root: "user_root"` (see [Workspace Root](workspaceroot.md)) and/or `terraform.backend.databricks_workspace: true`, all three share the same single SDK lookup - no redundant calls.
+
 ---
 
 ## Expressions
@@ -185,10 +203,11 @@ variables:
     prd: 4
 ```
 
-`settings.X` is also available inside expressions, alongside `vars.X`:
+`settings.X` and `current_user.X` are also available inside expressions, alongside `vars.X`:
 
 ```yaml
 name: ${{ 'prod-' + settings.workspace_root if vars.env == 'prd' else 'dev' }}
+path: ${{ '/Users/' + current_user.user_name + '/app' }}
 ```
 
 ### Context objects

--- a/docs/concepts/workspaceroot.md
+++ b/docs/concepts/workspaceroot.md
@@ -78,9 +78,9 @@ When both are enabled together, Laktory resolves your username only once and reu
 
 ## How the username is resolved
 
-Both `user_root` and `backend.databricks_workspace: true` resolve your identity the same way: they find a `DatabricksProvider` in the stack, build a Databricks SDK `WorkspaceClient` from whatever credentials are already configured on it (token, profile, service principal, ...), and call the SDK's current-user endpoint. If that provider is authenticated as a human, this is your email; if it's authenticated as a service principal (e.g. in CI/CD), it's the service principal's identity instead - "your own root" then really means "whoever/whatever this provider is authenticated as." Either way, no extra credentials or scopes are required beyond what the `DatabricksProvider` already needs.
+`user_root`, `backend.databricks_workspace: true`, and the [`${current_user.X}` variable namespace](variables.md#current-user) all resolve your identity the same way: they find a `DatabricksProvider` in the stack, build a Databricks SDK `WorkspaceClient` from whatever credentials are already configured on it (token, profile, service principal, ...), and call the SDK's current-user endpoint. If that provider is authenticated as a human, this is your email; if it's authenticated as a service principal (e.g. in CI/CD), it's the service principal's identity instead - "your own root" then really means "whoever/whatever this provider is authenticated as." Either way, no extra credentials or scopes are required beyond what the `DatabricksProvider` already needs.
 
-Because this is a live API call, commands that use it (`build`, `preview`, `deploy`, `destroy`, `validate`) need a real Databricks connection - unlike a stack that never touches either setting, which can run those commands with no live credentials at all.
+Because this is a live API call, commands that use it (`build`, `preview`, `deploy`, `destroy`, `validate`) need a real Databricks connection - unlike a stack that touches none of these, which can run those commands with no live credentials at all. When more than one of the three is used in the same stack, Laktory resolves your username only once and reuses it for all of them.
 
 ## Customizing the root
 

--- a/laktory/_current_user.py
+++ b/laktory/_current_user.py
@@ -1,0 +1,16 @@
+class CurrentUser:
+    """Live Databricks identity, exposed as the `${current_user.x}` template
+    namespace (see `docs/concepts/variables.md`).
+
+    `None` until a `Stack` build/preview/deploy/validate finds a
+    `${current_user.x}` reference somewhere in the stack and resolves it via
+    a live Databricks SDK call (see `Stack._resolve_user_root` in
+    `laktory/models/stacks/stack.py`) - never auto-injected or eagerly
+    fetched, to avoid a surprise network call for stacks that don't
+    reference it.
+    """
+
+    user_name: str | None = None
+
+
+current_user = CurrentUser()

--- a/laktory/_parsers.py
+++ b/laktory/_parsers.py
@@ -193,6 +193,32 @@ def _resolve_value(o, vars, objs, stringify=False):
     if not isinstance(o, str):
         return o
 
+    # Resolve ${current_user.<name>} syntax
+    pattern = re.compile(r"\$\{current_user\.([a-zA-Z_][a-zA-Z0-9_]*)\}")
+    for match in pattern.finditer(o):
+        # Extract the attribute name
+        attr_name = match.group(1)
+
+        # Resolve the current user value
+        resolved_value = _resolve_current_user(attr_name, vars, objs)
+
+        # Recursively resolve nested variables if variable value is a dict
+        # or a list, whether it ends up embedded (stringify) or returned
+        # as-is (whole-value replacement)
+        if isinstance(resolved_value, (list, dict)):
+            resolved_value = _resolve_values(resolved_value, vars, objs)
+
+        # Update the value with the resolved value
+        if isinstance(resolved_value, str):
+            o = o.replace(match.group(0), resolved_value)
+        elif stringify:
+            o = o.replace(match.group(0), json.dumps(resolved_value))
+        else:
+            o = resolved_value
+
+    if not isinstance(o, str):
+        return o
+
     # Resolve ${{ <expression> }} syntax
     pattern = re.compile(r"\$\{\{\s*(.*?)\s*\}\}")
     for match in pattern.finditer(o):
@@ -266,6 +292,40 @@ def _resolve_settings(name, vars, objs):
     return value
 
 
+def _get_current_user_value(name):
+    """Look up `name` on the `laktory._current_user.current_user` singleton.
+
+    Returns `None` if not yet resolved (no `Stack` has found and resolved a
+    `${current_user.x}` reference) or if `name` isn't a recognized attribute.
+    """
+    from laktory._current_user import current_user
+
+    return getattr(current_user, name.lower(), None)
+
+
+def _resolve_current_user(name, vars, objs):
+    """Resolve a `${current_user.<name>}` reference.
+
+    `laktory._current_user.current_user` is populated by `Stack` (see
+    `Stack._resolve_user_root` in `laktory/models/stacks/stack.py`) before
+    the general variable-resolution pass runs, so by the time this is
+    called the value should already be set. Returns the raw template
+    unresolved (matching `${settings.x}`'s behavior) if it isn't - e.g. when
+    resolving outside a `Stack` context.
+    """
+    value = _get_current_user_value(name)
+
+    # Value not found returning original value
+    if value is None:
+        return f"${{current_user.{name}}}"  # Default value if not resolved
+
+    # If the resolved value is itself a string with variables, resolve it
+    if isinstance(value, str) and ("${" in value or "$${" in value):
+        value = _resolve_value(value, vars, objs)
+
+    return value
+
+
 def _resolve_expression(expression, vars, objs):
     """Evaluate an inline expression."""
     # Names referenced as `vars.name` / `var.name` inside the expression
@@ -289,6 +349,17 @@ def _resolve_expression(expression, vars, objs):
         expression,
     )
 
+    # Names referenced as `current_user.name`, translated the same way
+    # (current_user.name -> current_user_map['name'])
+    referenced_current_user = set(
+        re.findall(r"\bcurrent_user\.([a-zA-Z_][a-zA-Z0-9_]*)\b", expression)
+    )
+    expression = re.sub(
+        r"\bcurrent_user\.([a-zA-Z_][a-zA-Z0-9_]*)\b",
+        r"current_user_map['\1']",
+        expression,
+    )
+
     # Prepare a safe evaluation context - shallow copy is sufficient because
     # eval() only reads from variables_map and never mutates var values.
     # Only the variables actually referenced by the expression are
@@ -303,8 +374,15 @@ def _resolve_expression(expression, vars, objs):
             local_context[name] = _resolve_variable(name, vars, objs)
 
     settings_context = {name: _get_settings_value(name) for name in referenced_settings}
+    current_user_context = {
+        name: _get_current_user_value(name) for name in referenced_current_user
+    }
 
-    locals = {"variables_map": local_context, "settings_map": settings_context}
+    locals = {
+        "variables_map": local_context,
+        "settings_map": settings_context,
+        "current_user_map": current_user_context,
+    }
 
     if objs is not None:
         for k, v in objs.items():

--- a/laktory/models/stacks/stack.py
+++ b/laktory/models/stacks/stack.py
@@ -10,6 +10,7 @@ from pydantic import Field
 from pydantic import field_validator
 from pydantic import model_validator
 
+from laktory._current_user import current_user
 from laktory._logger import get_logger
 from laktory._settings import settings
 from laktory.models.basemodel import BaseModel
@@ -124,6 +125,21 @@ def _resolve_databricks_provider_and_username(env):
     wc = db_provider.workspace_client
     username = wc.current_user.me().user_name
     return db_provider, wc, username
+
+
+_CURRENT_USER_REFERENCE_PATTERN = re.compile(r"current_user\.[a-zA-Z_]")
+
+
+def _references_current_user(env) -> bool:
+    """Cheap textual scan for a `current_user.x` reference anywhere in the
+    (not yet variable-resolved) stack - either the plain `${current_user.x}`
+    form or `current_user.x` inside a `${{ <expr> }}` expression - so the
+    live Databricks SDK username lookup is only made when actually needed.
+    `${current_user.x}` is opt-in and must never trigger a surprise network
+    call for a stack that doesn't reference it.
+    """
+    dump = json.dumps(env.model_dump(mode="json", exclude_unset=True), default=str)
+    return _CURRENT_USER_REFERENCE_PATTERN.search(dump) is not None
 
 
 def _user_workspace_root(username: str, stack_name: str, env_name: str | None) -> str:
@@ -563,11 +579,16 @@ class Stack(BaseModel):
     def _resolve_user_root(self, env: "Stack", env_name: str | None):
         """Resolve `settings.workspace_root: "user_root"` (if set) into a
         concrete, user/stack/env-scoped path and push it onto `env.settings`
-        (and, via `apply_settings()`, the global settings singleton).
+        (and, via `apply_settings()`, the global settings singleton). Also
+        resolves the `${current_user.x}` template namespace (see
+        `laktory/_current_user.py`) if referenced anywhere in the stack -
+        both need the exact same live Databricks SDK username lookup, made
+        at most once here.
 
         No-op unless `env.settings.workspace_root` is exactly the
-        `USER_ROOT_SENTINEL`. Requires a `DatabricksProvider` in the stack for
-        the live username lookup - same requirement as
+        `USER_ROOT_SENTINEL` or `${current_user.x}` is referenced somewhere
+        in `env`. Requires a `DatabricksProvider` in the stack whenever
+        either is triggered - same requirement as
         `backend.databricks_workspace`.
 
         Returns the `(db_provider, workspace_client, username)` it resolved
@@ -576,18 +597,35 @@ class Stack(BaseModel):
         (`to_terraform()`) can reuse it instead of making a second, redundant
         `current_user.me()` API call.
         """
-        if env.settings is None or env.settings.workspace_root != USER_ROOT_SENTINEL:
+        needs_root = (
+            env.settings is not None
+            and env.settings.workspace_root == USER_ROOT_SENTINEL
+        )
+        needs_current_user = _references_current_user(env)
+
+        if not needs_root and not needs_current_user:
             return None, None, None
 
         db_provider, wc, username = _resolve_databricks_provider_and_username(env)
         if db_provider is None:
+            if needs_root:
+                raise ValueError(
+                    f"settings.workspace_root: '{USER_ROOT_SENTINEL}' requires a "
+                    "DatabricksProvider in the stack."
+                )
             raise ValueError(
-                f"settings.workspace_root: '{USER_ROOT_SENTINEL}' requires a "
-                "DatabricksProvider in the stack."
+                "'${current_user.x}' requires a DatabricksProvider in the stack."
             )
 
-        env.settings.workspace_root = _user_workspace_root(username, env.name, env_name)
-        env.settings.apply_settings()
+        if needs_root:
+            env.settings.workspace_root = _user_workspace_root(
+                username, env.name, env_name
+            )
+            env.settings.apply_settings()
+
+        if needs_current_user:
+            current_user.user_name = username
+
         return db_provider, wc, username
 
     def build(self, env_name: str | None, inject_vars: bool = True, vars: dict = None):
@@ -645,6 +683,16 @@ class Stack(BaseModel):
                 orchestrator = r.orchestrator
                 if not orchestrator:
                     continue
+
+                # Orchestrator fields derived from `settings.workspace_root`
+                # (e.g. a LAKEFLOW_JOB task's `filepath`, a
+                # LAKEFLOW_DECLARATIVE_PIPELINE's `config_filepath`
+                # configuration entry) are computed by `update_from_parent()`,
+                # which first runs at initial model construction/validation -
+                # before `_resolve_user_root()` (above) has had a chance to
+                # resolve `workspace_root: "user_root"`. Re-run it now so
+                # those fields reflect the resolved root.
+                orchestrator.update_from_parent()
 
                 config_file = getattr(r.orchestrator, "config_file", None)
                 if config_file:

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -5,6 +5,7 @@ import pytest
 
 import laktory as lk
 from laktory import models
+from laktory._current_user import current_user
 from laktory._settings import settings
 from laktory._testing import skip_terraform_plan
 
@@ -1126,3 +1127,285 @@ def test_workspace_root_user_root_lakeflow_job_permissions_depends_on(monkeypatc
     m = re.match(r"^\$\{resources\.([^}]+)\}$", dep)
     dep_name = m.group(1) if m else dep.split(".", 1)[1]
     assert dep_name in resource_names
+
+
+def test_workspace_root_user_root_lakeflow_job_config_filepath(monkeypatch):
+    """Regression for #630: a LAKEFLOW_JOB pipeline's own job definition -
+    the task's `named_parameters.filepath` and the job's dependency/library
+    spec - must reflect the resolved `settings.workspace_root: "user_root"`
+    value, not the raw unresolved root. `LakeflowJobOrchestrator.
+    update_from_parent()` first runs at initial model construction/
+    validation, before `Stack._resolve_user_root()` has a chance to resolve
+    the sentinel, so these fields were getting baked in with the wrong root
+    and never recomputed."""
+    from unittest.mock import MagicMock
+    from unittest.mock import PropertyMock
+    from unittest.mock import patch
+
+    from laktory.models.resources.providers.databricksprovider import DatabricksProvider
+
+    monkeypatch.setattr(settings, "workspace_root", settings.workspace_root)
+
+    mock_wc = MagicMock()
+    mock_wc.current_user.me.return_value.user_name = "user@test.com"
+
+    pl = models.Pipeline(
+        name="pl-job",
+        dependencies=["${vars.wheel_filepath}"],
+        nodes=[
+            {
+                "name": "brz",
+                "sources": [{"format": "JSON", "path": "/brz_source/"}],
+                "sinks": [
+                    {"format": "PARQUET", "mode": "APPEND", "path": "/brz_sink/"}
+                ],
+            },
+        ],
+        orchestrator={
+            "type": "LAKEFLOW_JOB",
+            "name": "pl-job",
+            "serverless_environment_version": "5",
+        },
+    )
+
+    with patch.object(
+        DatabricksProvider, "workspace_client", new_callable=PropertyMock
+    ) as mock_prop:
+        mock_prop.return_value = mock_wc
+
+        stack = models.Stack(
+            name="my-stack",
+            environments={"dev": {"variables": {}}},
+            variables={
+                "wheel_filepath": "/Workspace${settings.workspace_root}wheels/udp-0.0.1-py3-none-any.whl"
+            },
+            resources={
+                "providers": {"databricks": _DB_PROVIDER},
+                "pipelines": {"pl-job": pl.model_dump(exclude_unset=True)},
+            },
+            settings={"workspace_root": "user_root"},
+        )
+        d = stack.to_terraform(env_name="dev").model_dump()
+
+    root = "/Users/user@test.com/.laktory/my-stack/dev/"
+    assert settings.workspace_root == root
+
+    # `databricks_workspace_file` resource (already known to resolve correctly)
+    file_path = next(iter(d["resource"]["databricks_workspace_file"].values()))["path"]
+    assert file_path == f"{root}pipelines/pl-job.json"
+
+    # Job task's own `filepath` parameter must point at the same file
+    job = next(iter(d["resource"]["databricks_job"].values()))
+    task = job["task"][0]
+    assert task["python_wheel_task"]["named_parameters"]["filepath"] == (
+        f"/Workspace{file_path}"
+    )
+
+    # Environment dependency (serverless) must use the resolved root too
+    dep = job["environment"][0]["spec"]["dependencies"][0]
+    assert dep == f"/Workspace{root}wheels/udp-0.0.1-py3-none-any.whl"
+
+
+def test_workspace_root_user_root_lakeflow_declarative_pipeline_config_filepath(
+    monkeypatch,
+):
+    """Regression for #630: same as
+    test_workspace_root_user_root_lakeflow_job_config_filepath, but for the
+    LAKEFLOW_DECLARATIVE_PIPELINE orchestrator, whose `update_from_parent()`
+    bakes `settings.workspace_root` into `configuration['laktory.
+    config_filepath']` via the exact same early-construction pattern."""
+    from unittest.mock import MagicMock
+    from unittest.mock import PropertyMock
+    from unittest.mock import patch
+
+    from laktory.models.resources.providers.databricksprovider import DatabricksProvider
+
+    monkeypatch.setattr(settings, "workspace_root", settings.workspace_root)
+
+    mock_wc = MagicMock()
+    mock_wc.current_user.me.return_value.user_name = "user@test.com"
+
+    pl = models.Pipeline(
+        name="pl-ldp",
+        nodes=[
+            {
+                "name": "brz",
+                "sources": [{"format": "JSON", "path": "/brz_source/"}],
+                "sinks": [{"schema_name": "s", "table_name": "brz"}],
+            },
+        ],
+        orchestrator={
+            "type": "LAKEFLOW_DECLARATIVE_PIPELINE",
+            "name": "pl-ldp",
+            "catalog": "c",
+            "target": "s",
+        },
+    )
+
+    with patch.object(
+        DatabricksProvider, "workspace_client", new_callable=PropertyMock
+    ) as mock_prop:
+        mock_prop.return_value = mock_wc
+
+        stack = models.Stack(
+            name="my-stack",
+            environments={"dev": {"variables": {}}},
+            resources={
+                "providers": {"databricks": _DB_PROVIDER},
+                "pipelines": {"pl-ldp": pl.model_dump(exclude_unset=True)},
+            },
+            settings={"workspace_root": "user_root"},
+        )
+        d = stack.to_terraform(env_name="dev").model_dump()
+
+    root = "/Users/user@test.com/.laktory/my-stack/dev/"
+    assert settings.workspace_root == root
+
+    file_path = next(iter(d["resource"]["databricks_workspace_file"].values()))["path"]
+    assert file_path == f"{root}pipelines/pl-ldp.json"
+
+    pipeline = next(iter(d["resource"]["databricks_pipeline"].values()))
+    assert pipeline["configuration"]["laktory.config_filepath"] == (
+        f"/Workspace{file_path}"
+    )
+
+
+def test_current_user_variable_resolves(monkeypatch):
+    """`${current_user.user_name}` resolves to the live Databricks username,
+    the same way `${{ current_user.user_name }}` does inside an expression."""
+    from unittest.mock import MagicMock
+    from unittest.mock import PropertyMock
+    from unittest.mock import patch
+
+    from laktory.models.resources.providers.databricksprovider import DatabricksProvider
+
+    monkeypatch.setattr(current_user, "user_name", current_user.user_name)
+
+    mock_wc = MagicMock()
+    mock_wc.current_user.me.return_value.user_name = "user@test.com"
+
+    with patch.object(
+        DatabricksProvider, "workspace_client", new_callable=PropertyMock
+    ) as mock_prop:
+        mock_prop.return_value = mock_wc
+
+        stack = models.Stack(
+            name="my-stack",
+            environments={"dev": {"variables": {}}},
+            resources={
+                "providers": {"databricks": _DB_PROVIDER},
+                "databricks_notebooks": {
+                    "nb": {
+                        "source": "./test_stack.py",
+                        "dirpath": "foo/${current_user.user_name}",
+                    },
+                    "nb2": {
+                        "source": "./test_stack.py",
+                        "dirpath": "${{ 'bar-' + current_user.user_name }}",
+                    },
+                },
+            },
+        )
+        d = stack.to_terraform(env_name="dev").model_dump()
+
+    assert current_user.user_name == "user@test.com"
+    notebooks = d["resource"]["databricks_notebook"]
+    assert notebooks["nb"]["path"] == "/.laktory/foo/user@test.com/test_stack.py"
+    assert notebooks["nb2"]["path"] == "/.laktory/bar-user@test.com/test_stack.py"
+
+
+def test_current_user_variable_not_referenced_makes_no_sdk_call(monkeypatch):
+    """A stack that never references `${current_user.x}` must not trigger a
+    live Databricks SDK lookup - it's opt-in, not auto-injected."""
+    from unittest.mock import MagicMock
+    from unittest.mock import PropertyMock
+    from unittest.mock import patch
+
+    from laktory.models.resources.providers.databricksprovider import DatabricksProvider
+
+    monkeypatch.setattr(current_user, "user_name", current_user.user_name)
+
+    mock_wc = MagicMock()
+    mock_wc.current_user.me.return_value.user_name = "user@test.com"
+
+    with patch.object(
+        DatabricksProvider, "workspace_client", new_callable=PropertyMock
+    ) as mock_prop:
+        mock_prop.return_value = mock_wc
+
+        stack = models.Stack(
+            name="my-stack",
+            environments={"dev": {"variables": {}}},
+            resources={
+                "providers": {"databricks": _DB_PROVIDER},
+                "databricks_notebooks": {
+                    "nb": {"source": "./test_stack.py", "dirpath": "foo"}
+                },
+            },
+        )
+        stack.to_terraform(env_name="dev")
+
+    assert current_user.user_name is None
+    mock_wc.current_user.me.assert_not_called()
+
+
+def test_current_user_variable_requires_databricks_provider():
+    """Referencing `${current_user.x}` without a `DatabricksProvider` in the
+    stack raises a clear error instead of silently leaving it unresolved."""
+    stack = models.Stack(
+        name="my-stack",
+        resources={
+            "databricks_notebooks": {
+                "nb": {
+                    "source": "./test_stack.py",
+                    "dirpath": "foo/${current_user.user_name}",
+                }
+            },
+        },
+    )
+    with pytest.raises(ValueError, match=r"current_user"):
+        stack.build(env_name=None)
+
+
+def test_current_user_variable_shares_single_lookup_with_user_root_and_backend(
+    monkeypatch,
+):
+    """`${current_user.x}`, `settings.workspace_root: "user_root"`, and
+    `backend.databricks_workspace: true` all need the same live username -
+    combined in one stack, they must share a single SDK call."""
+    from unittest.mock import MagicMock
+    from unittest.mock import PropertyMock
+    from unittest.mock import patch
+
+    from laktory.models.resources.providers.databricksprovider import DatabricksProvider
+
+    monkeypatch.setattr(settings, "workspace_root", settings.workspace_root)
+    monkeypatch.setattr(current_user, "user_name", current_user.user_name)
+
+    mock_wc = MagicMock()
+    mock_wc.current_user.me.return_value.user_name = "user@test.com"
+
+    with patch.object(
+        DatabricksProvider, "workspace_client", new_callable=PropertyMock
+    ) as mock_prop:
+        mock_prop.return_value = mock_wc
+
+        stack = models.Stack(
+            name="my-stack",
+            environments={"dev": {"variables": {}}},
+            resources={
+                "providers": {"databricks": _DB_PROVIDER},
+                "databricks_notebooks": {
+                    "nb": {
+                        "source": "./test_stack.py",
+                        "dirpath": "foo/${current_user.user_name}",
+                    }
+                },
+            },
+            settings={"workspace_root": "user_root"},
+            terraform={"backend": {"databricks_workspace": True}},
+        )
+        stack.to_terraform(env_name="dev")
+
+    assert current_user.user_name == "user@test.com"
+    mock_wc.current_user.me.assert_called_once()


### PR DESCRIPTION
Fixes #630

## Summary
- `LakeflowJobOrchestrator`/`LakeflowDeclarativePipelineOrchestrator.update_from_parent()` baked `settings.workspace_root`-derived paths (job task `filepath`, dependency/library paths, `config_filepath`) into stored fields at initial model construction/validation - before `Stack._resolve_user_root()` had a chance to resolve `workspace_root: "user_root"`. The deployed job's own config never reflected the resolved root even though Terraform resource attributes (e.g. `databricks_workspace_file.path`) did, causing `FileNotFoundError` / library-install failures at runtime.
- Fixed by re-running `orchestrator.update_from_parent()` in `Stack.build()`'s pipeline-config-writing loop, after root resolution has already happened - a generic fix that covers both orchestrator types.
- Audited every other consumer of `settings.workspace_root`/`build_root`/`runtime_root` in the codebase; confirmed this eager-bake pattern was isolated to those two `update_from_parent()` methods - everything else is already a lazy `@computed_field`/property or an explicitly late call.
- Added a new `${current_user.x}` variable namespace (currently `user_name`), mirroring `${settings.x}`, exposing the live Databricks identity resolved via the SDK. Resolved lazily - only if actually referenced somewhere in the stack (plain `${current_user.x}` or inside a `${{ expr }}`) - and shares a single SDK lookup with `workspace_root: "user_root"` / `backend.databricks_workspace: true` when combined. Raises a clear error if referenced without a `DatabricksProvider` in the stack.

## Test plan
- [x] `tests/test_stack.py -k workspace_root` (8 tests, including 2 new #630 regressions for LAKEFLOW_JOB and LAKEFLOW_DECLARATIVE_PIPELINE) and `-k current_user` (4 new tests) - all pass
- [x] Confirmed the new regression tests fail on pre-fix code and pass after the fix
- [x] Full suite: `uv run pytest -m "not databricks_connect" --cov=laktory tests` - 934 passed, 3 pre-existing/environment-only failures (missing live Databricks credentials, local streaming checkpoint flakiness) verified to fail identically on unmodified `main`