### PR TITLE
Fix custom_writer.parent not assigned on table-based sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * `depends_on` on a LAKEFLOW_JOB pipeline's auto-generated config-file `Permissions` resource pointing at a nonexistent resource when `settings.workspace_root: "user_root"` is used, causing `terraform plan` to fail [[#629](https://github.com/okube-ai/laktory/issues/629)]
 * A `LAKEFLOW_JOB` or `LAKEFLOW_DECLARATIVE_PIPELINE` pipeline's own job/config definition (task `filepath`, dependency/library paths, `config_filepath`) baked in the raw, unresolved `settings.workspace_root` instead of the `"user_root"`-resolved value, causing the deployed job to fail with `FileNotFoundError` / library-install errors [[#630](https://github.com/okube-ai/laktory/issues/630)]
 * Checkpoint purge (`DataSink` and `PipelineNode` expectations) no longer falls through to a DBFS API probe after already deleting the checkpoint via the plain filesystem - previously this happened unconditionally, which could error out on a DBFS-disabled workspace even though the checkpoint was already correctly removed (e.g. via a Unity Catalog Volume `runtime_root`)
+* `custom_writer.parent` is now correctly assigned on table-based sinks (`UnityCatalogDataSink`, `HiveMetastoreDataSink`) - `TableDataSink.children_names` previously omitted `"custom_writer"`, so `laktory_context.sink` was always `None` inside custom writer functions targeting those sinks [[#636](https://github.com/okube-ai/laktory/issues/636)]
 
 
 ## [0.12.4] - 2026-08-28

--- a/laktory/models/datasinks/tabledatasink.py
+++ b/laktory/models/datasinks/tabledatasink.py
@@ -126,6 +126,7 @@ class TableDataSink(BaseDataSink):
     def children_names(self):
         return [
             "metadata",
+            "custom_writer",
         ]
 
     # ----------------------------------------------------------------------- #

--- a/tests/datasinks/test_unitycatalogdatasink.py
+++ b/tests/datasinks/test_unitycatalogdatasink.py
@@ -58,3 +58,14 @@ def test_full_name():
     )
     assert sink.schema_name == "default"
     assert sink.table_name == "df"
+
+
+def test_custom_writer_parent():
+    sink = UnityCatalogDataSink(
+        catalog_name="sandbox",
+        schema_name="default",
+        table_name="df",
+        custom_writer={"func_name": "mypackage.etl.my_write"},
+    )
+    assert "custom_writer" in sink.children_names
+    assert sink.custom_writer.parent is sink


### PR DESCRIPTION
TableDataSink.children_names overrode BaseDataSink's list with just ["metadata"], dropping "custom_writer" - so _assign_parent_to_children() never set CustomWriter.parent on UnityCatalogDataSink/HiveMetastoreDataSink, leaving laktory_context.sink None inside custom writer functions.

Fixes #636