### PR TITLE
Fix backslash-corrupted workspace_root on Windows in build_resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 * n/a
 ### Fixed
-* n/a
+* Fixed `laktory.dab.build_resources` computing `workspace_root` with OS-native (backslash) separators on Windows, breaking the deployed job's file path on remote Unix compute. [[#639](https://github.com/okube-ai/laktory/issues/639)]
 ### Updated
 * n/a
 ### Breaking changes

--- a/laktory/dab.py
+++ b/laktory/dab.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from pathlib import Path
+from pathlib import PureWindowsPath
 
 from laktory._logger import get_logger
 from laktory._settings import DEFAULT_BUILD_ROOT
@@ -92,9 +93,14 @@ def build_resources(bundle):
                 "Variable `dab_workspace_root` must be set to '${workspace.root_path}' in databricks.yml to use Laktory."
             )
 
-        # Build Path relative to Bundle root
+        # Build Path relative to Bundle root. Normalized via PureWindowsPath
+        # (which accepts both "\" and "/" as separators, regardless of host
+        # OS) since workspace_root represents a remote (Unix) Databricks
+        # path, even though os.path.relpath returns OS-native (backslash on
+        # Windows) separators.
         build_root_abs = settings.build_root
         build_root_rel = os.path.relpath(build_root_abs, bundle_dirpath)
+        build_root_rel = PureWindowsPath(build_root_rel).as_posix()
         settings.workspace_root = (
             f"{dab_workspace_root}/{_DAB_FILES_SUBDIR}/{build_root_rel}/"
         )

--- a/tests/test_dab.py
+++ b/tests/test_dab.py
@@ -435,6 +435,29 @@ def test_workspace_root_auto_set(tmp_path, mock_bundle, monkeypatch):
     assert settings.workspace_root == f"{stripped_root}/files/{expected_rel}/"
 
 
+def test_workspace_root_posix_on_windows_style_relpath(
+    tmp_path, mock_bundle, monkeypatch
+):
+    """workspace_root never contains backslashes, even if os.path.relpath returns
+    Windows-style (backslash) separators, as it does on a Windows host."""
+    import laktory.dab as dab_module
+    from laktory._settings import settings
+
+    laktory_pipelines_dir = _make_pipelines_dir(tmp_path, _PIPELINE_DLT_YAML)
+    monkeypatch.chdir(tmp_path)
+    mock_bundle.variables["laktory_pipelines_dir"] = str(laktory_pipelines_dir)
+
+    monkeypatch.setattr(
+        dab_module.os.path, "relpath", lambda *a, **k: "laktory\\.build"
+    )
+
+    dab_module.build_resources(mock_bundle)
+
+    stripped_root = _FAKE_WORKSPACE_ROOT.replace("/Workspace/", "/")
+    assert "\\" not in settings.workspace_root
+    assert settings.workspace_root == f"{stripped_root}/files/laktory/.build/"
+
+
 def test_workspace_root_no_bundle_var(tmp_path, mock_bundle, monkeypatch):
     """When dab_workspace_root bundle variable is absent, load_resources() raises ValueError."""
     from laktory.dab import build_resources


### PR DESCRIPTION
Fixes #639

## Summary
- `laktory.dab.build_resources` computed `build_root_rel` via `os.path.relpath`, which returns OS-native (backslash) separators on Windows.
- That value flows unmodified into `settings.workspace_root` - a *remote* Unix Databricks path embedded in the deployed job's `python_wheel_task.named_parameters.filepath` - so every task failed at runtime with `FileNotFoundError` on Windows, despite `databricks bundle deploy` succeeding cleanly.
- Normalized `build_root_rel` via `PureWindowsPath(...).as_posix()`, which deterministically parses both `\` and `/` as separators regardless of host OS, so the fix is verifiable on POSIX CI (not just on an actual Windows machine).
- `settings.build_root` itself is left untouched since it's only used for local filesystem operations (`Path.mkdir()`, `shutil.rmtree()`), where native separators are correct.

## Test plan
- [x] `uv run pytest tests/test_dab.py -v` - 21 passed, including a new regression test that monkeypatches `os.path.relpath` to return a Windows-style backslash path and asserts `workspace_root` contains none.
- [x] `uv run pytest tests/ -k "orchestrator or dab or pipelineconfig"` - 79 passed, 1 xfailed (pre-existing/unrelated).
- [x] `ruff check` / `ruff format --check` on changed files.
- [x] Full suite (`uv run pytest -m "not databricks_connect" --cov=laktory tests`) - 938 passed, 77 skipped, 4 deselected, 4 xfailed. 3 failures observed, all pre-existing/environment-only and unrelated to this change: `test_data_quality_monitors.py::test_update_data_profiling_configs_skips_when_explicitly_unmanaged` fails identically on `main` (missing Databricks credentials); the two streaming pyspark tests (`test_execute.py::test_streaming_execute`, `test_end_to_end.py::test_streaming_e2e`) are order-dependent flakes and pass individually.