### PR TITLE
Fix DataFrameExpr splitting SQL on a semicolon inside a comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * n/a
 ### Fixed
 * Fixed `laktory.dab.build_resources` computing `workspace_root` with OS-native (backslash) separators on Windows, breaking the deployed job's file path on remote Unix compute. [[#639](https://github.com/okube-ai/laktory/issues/639)]
+* Fixed `DataFrameExpr` (SQL `expr:` pipeline nodes) splitting on a bare `;`, causing a `;` inside a `-- comment` to silently truncate/corrupt the query - `expr:` must now be a single SQL statement, enforced with a clear validation error instead of a confusing backend parse error. [[#640](https://github.com/okube-ai/laktory/issues/640)]
 ### Updated
 * n/a
 ### Breaking changes

--- a/docs/concepts/transformer.md
+++ b/docs/concepts/transformer.md
@@ -19,7 +19,9 @@ API, but it can also be configured to use the selected DataFrame backend API.
 ??? "API Documentation"
     [`laktory.models.DataFrameExpr`][laktory.models.DataFrameExpr]<br>
 
-The `DataFrameExpr` class expresses a transformation as a `SELECT` SQL expression, including joins and unions.
+The `DataFrameExpr` class expresses a transformation as a `SELECT` SQL expression, including joins and unions. It
+must be a single SQL statement - `;`-separated multi-statement scripts are not supported, including a `;` appearing
+inside a `-- comment`.
 
 #### DataFrameMethod
 ??? "API Documentation"

--- a/laktory/models/dataframe/dataframeexpr.py
+++ b/laktory/models/dataframe/dataframeexpr.py
@@ -6,6 +6,7 @@ from typing import Literal
 # from typing import Literal
 import narwhals as nw
 from pydantic import Field
+from pydantic import field_validator
 
 from laktory._logger import get_logger
 from laktory.enums import DataFrameBackends
@@ -37,6 +38,71 @@ def to_safe_expr(expr, df_names=None):
         expr = expr.replace("{" + df_name + "}", f"__{df_name}__")
 
     return expr
+
+
+_LINE_COMMENT_RE = re.compile(r"--[^\n]*")
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+
+def _iter_top_level_semicolons(expr: str):
+    """Yield the index of every `;` in `expr` not inside a `--`/`/* */`
+    comment or a quoted string/identifier literal (`'`, `"`, `` ` ``)."""
+    in_line_comment = False
+    in_block_comment = False
+    quote_char = None
+    i, n = 0, len(expr)
+    while i < n:
+        c = expr[i]
+        nxt = expr[i + 1] if i + 1 < n else ""
+        if in_line_comment:
+            if c == "\n":
+                in_line_comment = False
+            i += 1
+        elif in_block_comment:
+            if c == "*" and nxt == "/":
+                in_block_comment = False
+                i += 2
+            else:
+                i += 1
+        elif quote_char:
+            if c == quote_char:
+                if nxt == quote_char:  # doubled-quote escape
+                    i += 2
+                    continue
+                quote_char = None
+            i += 1
+        elif c == "-" and nxt == "-":
+            in_line_comment = True
+            i += 2
+        elif c == "/" and nxt == "*":
+            in_block_comment = True
+            i += 2
+        elif c in ("'", '"', "`"):
+            quote_char = c
+            i += 1
+        elif c == ";":
+            yield i
+            i += 1
+        else:
+            i += 1
+
+
+def validate_single_statement(expr: str) -> None:
+    """Raise if `expr` contains more than one SQL statement - a `;` outside
+    of comments/literals that isn't simply the trailing terminator."""
+    positions = list(_iter_top_level_semicolons(expr))
+    if not positions:
+        return
+
+    tail = expr[positions[-1] + 1 :]
+    tail = _LINE_COMMENT_RE.sub("", tail)
+    tail = _BLOCK_COMMENT_RE.sub("", tail)
+    if len(positions) > 1 or tail.strip():
+        raise ValueError(
+            "DataFrameExpr `expr` must be a single SQL statement. Found a "
+            "statement-separating ';' (outside of comments and string "
+            "literals) that is not just a trailing terminator."
+        )
 
 
 # --------------------------------------------------------------------------- #
@@ -79,11 +145,23 @@ class DataFrameExpr(BaseModel, PipelineChild):
     ```
     """
 
-    expr: str = Field(..., description="SQL Expression")
+    expr: str = Field(
+        ...,
+        description=(
+            "SQL Expression. Must be a single SQL statement - multiple "
+            "`;`-separated statements are not supported, including a `;` "
+            "appearing inside a `-- comment`."
+        ),
+    )
     type: Literal["SQL"] = Field(
         "SQL",
         description="Expression type. Only SQL is currently supported, but `DF` could be added in the future.",
     )
+
+    @field_validator("expr")
+    def check_single_statement(cls, v: str) -> str:
+        validate_single_statement(v)
+        return v
 
     @property
     def is_sql_expressible(self) -> bool:
@@ -206,7 +284,6 @@ class DataFrameExpr(BaseModel, PipelineChild):
 
             from laktory import is_sdp_execute
 
-            _df = None
             if is_sdp_execute():
                 # Spark Connect (SDP): createOrReplaceTempView is forbidden inside
                 # @dp.* decorated functions. Use spark.sql(**kwargs) instead -
@@ -225,10 +302,7 @@ class DataFrameExpr(BaseModel, PipelineChild):
                     sql_kwargs[safe_k] = v
                     query = query.replace("{{" + k + "}}", "{" + safe_k + "}")
 
-                for stmt in query.split(";"):
-                    if stmt.replace("\n", " ").strip() == "":
-                        continue
-                    _df = _spark.sql(stmt, **sql_kwargs)
+                _df = _spark.sql(query, **sql_kwargs)
             else:
                 # Local / LDP: use createOrReplaceTempView.
                 # LDP monkey-patches spark.sql() and does not support **kwargs.
@@ -239,13 +313,8 @@ class DataFrameExpr(BaseModel, PipelineChild):
                     query = query.replace("{" + k + "}", safe_k)
                     v.createOrReplaceTempView(safe_k)
 
-                for stmt in query.split(";"):
-                    if stmt.replace("\n", " ").strip() == "":
-                        continue
-                    _df = _spark.sql(stmt)
+                _df = _spark.sql(query)
 
-            if _df is None:
-                raise ValueError(f"SQL Expression '{self.expr}' is invalid")
             return nw.from_native(_df)
 
         else:

--- a/tests/dataframe/test_dataframeexpr.py
+++ b/tests/dataframe/test_dataframeexpr.py
@@ -1,6 +1,7 @@
 import narwhals as nw
 import polars as pl
 import pytest
+from pydantic import ValidationError
 
 import laktory as lk
 from laktory._testing import get_df0
@@ -70,3 +71,68 @@ def test_sql_with_curly(backend):
             }
         ),
     )
+
+
+# ---------------------------------------------------------------------------
+# Single-statement enforcement (issue #640)
+# ---------------------------------------------------------------------------
+
+_COMMENT_SEMICOLON_EXPR = """
+SELECT
+    id,
+    -- TODO: rule isn't specified in the sheet's notes; passthrough for now
+    x1
+FROM
+    {df}
+"""
+
+
+@pytest.mark.parametrize("backend", ["POLARS", "PYSPARK"])
+def test_sql_expr_comment_with_semicolon(backend):
+    """A `;` inside a `-- comment` is not mistaken for a statement separator."""
+    df0 = get_df0(backend)
+
+    node = lk.models.DataFrameExpr(expr=_COMMENT_SEMICOLON_EXPR)
+    df = node.to_df({"df": df0})
+    assert_dfs_equal(
+        df.select("id", "x1"),
+        pl.DataFrame({"id": ["a", "b", "c"], "x1": [1, 2, 3]}),
+    )
+
+
+def test_sql_expr_comment_with_semicolon_sdp(monkeypatch):
+    """Same as above, but through the Spark Connect / SDP execution branch."""
+    monkeypatch.setattr(lk, "is_sdp_execute", lambda: True)
+    df0 = get_df0("PYSPARK")
+
+    node = lk.models.DataFrameExpr(expr=_COMMENT_SEMICOLON_EXPR)
+    df = node.to_df({"df": df0})
+    assert_dfs_equal(
+        df.select("id", "x1"),
+        pl.DataFrame({"id": ["a", "b", "c"], "x1": [1, 2, 3]}),
+    )
+
+
+def test_sql_expr_trailing_semicolon_allowed():
+    """A single trailing `;` terminator is still valid."""
+    lk.models.DataFrameExpr(expr="SELECT id FROM {df};")
+    lk.models.DataFrameExpr(expr="SELECT id FROM {df}; -- done")
+
+
+def test_sql_expr_semicolon_in_literal_allowed():
+    """A `;` inside a string or backtick-quoted identifier is not a separator."""
+    lk.models.DataFrameExpr(expr="SELECT 'a;b' AS x FROM {df}")
+    lk.models.DataFrameExpr(expr="SELECT `a;b` FROM {df}")
+
+
+def test_sql_expr_rejects_multi_statement():
+    """A genuine multi-statement `expr` raises a clear validation error."""
+    with pytest.raises(ValidationError, match="single SQL statement"):
+        lk.models.DataFrameExpr(expr="SELECT id FROM {df}; SELECT id FROM {df}")
+
+
+def test_sql_expr_rejects_semicolon_mid_statement():
+    """A `;` followed by more statement content (not just a trailing
+    terminator) raises, even without a second full statement."""
+    with pytest.raises(ValidationError, match="single SQL statement"):
+        lk.models.DataFrameExpr(expr="SELECT id; FROM {df}")


### PR DESCRIPTION
Fixes #640

## Summary
- `DataFrameExpr.to_df`'s PySpark backend split the SQL `expr` on a bare `;` (`query.split(";")`, both the SDP and local/LDP branches) with no awareness of `-- comment` text. A `;` inside a comment silently split one valid statement into two broken fragments, executed independently, with only the last non-empty fragment's result kept - surfacing as a confusing `PARSE_SYNTAX_ERROR` pointing at the wrong location.
- Removed the split entirely: `query` is now passed to `_spark.sql()` once in both branches. Verified Spark's own parser already tolerates a single trailing `;` gracefully, so no functionality is lost for the common "trailing semicolon" style.
- Added a `@field_validator("expr")` on `DataFrameExpr` that scans for a genuine statement-separating `;` - one that isn't inside a `--`/`/* */` comment or a quoted string/identifier literal, and isn't simply the trailing terminator - and raises a clear `ValidationError` at model-construction time instead of relying on a backend-specific parse error. Confirmed Polars' own `SQLContext` already rejects multi-statement input on its own, so this validator makes behavior consistent and fails fast across both backends.
- Documented the single-statement requirement on the `expr` field description and in `docs/concepts/transformer.md`.

## Test plan
- [x] `uv run pytest tests/dataframe/test_dataframeexpr.py -v` - 13 passed, including new regression tests: comment-embedded `;` executes correctly (Polars, PySpark local/LDP, PySpark SDP), a genuine multi-statement `expr` is rejected with a clear error, and edge cases (trailing `;`, `;` inside string/backtick literals) remain valid.
- [x] `uv run pytest tests/dataframe/ tests/pipeline/ -q` - 236 passed, 2 failures both pre-existing/environment-only (missing Databricks credentials), unrelated to this change.
- [x] `ruff check` / `ruff format --check` on changed files (one pre-existing, unrelated `RUF015` warning confirmed present on `main` before this change).
- [x] Full suite (`uv run pytest -m "not databricks_connect" --cov=laktory tests`) - 947 passed, 77 skipped, 4 deselected, 4 xfailed. 1 failure: `test_data_quality_monitors.py::test_update_data_profiling_configs_skips_when_explicitly_unmanaged`, confirmed pre-existing/environment-only (missing Databricks credentials) and unrelated to this change.