### PR TITLE
Fix AGENTS.md's false claim about DAB orchestrator requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * Fixed `laktory.dab.build_resources` computing `workspace_root` with OS-native (backslash) separators on Windows, breaking the deployed job's file path on remote Unix compute. [[#639](https://github.com/okube-ai/laktory/issues/639)]
 * Fixed `DataFrameExpr` (SQL `expr:` pipeline nodes) splitting on a bare `;`, causing a `;` inside a `-- comment` to silently truncate/corrupt the query - `expr:` must now be a single SQL statement, enforced with a clear validation error instead of a confusing backend parse error. [[#640](https://github.com/okube-ai/laktory/issues/640)]
+* Fixed `laktory/AGENTS.md` incorrectly claiming a Pipeline YAML doesn't need `orchestrator.type` when deploying via DABs; a pipeline with no orchestrator is actually skipped entirely (no resource created, in both DABs and Terraform/Pulumi), now logged as a warning instead of an easy-to-miss INFO log. [[#643](https://github.com/okube-ai/laktory/issues/643)]
 ### Updated
 * n/a
 ### Breaking changes

--- a/laktory/AGENTS.md
+++ b/laktory/AGENTS.md
@@ -776,7 +776,7 @@ targets:
 Key differences from Terraform:
 - `targets` (dev/prd) replace Stack `environments`
 - Account-level resources (groups, metastore) still require Terraform
-- Pipeline YAML does not need `orchestrator.type` — DABs creates the job automatically
+- Pipeline YAML still needs `orchestrator.type` — DABs uses it to create the matching job/pipeline resource; a pipeline with no orchestrator is skipped silently (no error)
 - Use `databricks bundle deploy` instead of `laktory deploy`
 
 ---

--- a/laktory/dab.py
+++ b/laktory/dab.py
@@ -150,7 +150,7 @@ def build_resources(bundle):
 
             orchestrator = pl.orchestrator
             if not orchestrator:
-                logger.info(f"Pipeline '{pl.name}' has no orchestrator. Skipping.")
+                logger.warning(f"Pipeline '{pl.name}' has no orchestrator. Skipping.")
                 continue
 
             # Write pipeline config JSON for DABs to sync to the workspace

--- a/laktory/models/stacks/stack.py
+++ b/laktory/models/stacks/stack.py
@@ -689,6 +689,9 @@ class Stack(BaseModel):
             if isinstance(r, Pipeline):
                 orchestrator = r.orchestrator
                 if not orchestrator:
+                    logger.warning(
+                        f"Pipeline '{r.name}' has no orchestrator. Skipping."
+                    )
                     continue
 
                 # Orchestrator fields derived from `settings.workspace_root`

--- a/tests/test_dab.py
+++ b/tests/test_dab.py
@@ -204,6 +204,17 @@ nodes:
       - table_name: brz_stocks
 """
 
+# Pipeline with no orchestrator - produces no DAB resource (issue #643)
+_PIPELINE_NO_ORCHESTRATOR_YAML = """\
+name: pl-no-orchestrator
+nodes:
+  - name: brz_stocks
+    sources:
+    - table_name: samples.nyctaxi.trips
+    sinks:
+      - table_name: brz_stocks
+"""
+
 # Pipeline with a ${var.env} reference
 _PIPELINE_WITH_VAR_YAML = """\
 name: pl-${var.env}
@@ -359,6 +370,29 @@ def test_load_resources_missing_dir_skipped(tmp_path, mock_bundle, monkeypatch):
 
     resources = build_resources(mock_bundle)
     assert len(resources.pipelines) == 0
+
+
+def test_load_resources_no_orchestrator_skipped_with_warning(
+    tmp_path, mock_bundle, monkeypatch
+):
+    """A pipeline with no orchestrator produces no DAB resource, and this is
+    logged as a warning, not an easy-to-miss INFO log (issue #643)."""
+    import laktory.dab as dab_module
+
+    laktory_pipelines_dir = _make_pipelines_dir(
+        tmp_path, _PIPELINE_NO_ORCHESTRATOR_YAML, filename="pl-no-orchestrator.yaml"
+    )
+    monkeypatch.chdir(tmp_path)
+    mock_bundle.variables["laktory_pipelines_dir"] = str(laktory_pipelines_dir)
+
+    warnings = []
+    monkeypatch.setattr(dab_module.logger, "warning", warnings.append)
+
+    resources = dab_module.build_resources(mock_bundle)
+
+    assert len(resources.pipelines) == 0
+    assert len(resources.jobs) == 0
+    assert any("pl-no-orchestrator' has no orchestrator" in w for w in warnings)
 
 
 def test_load_resources_default_dir(tmp_path, mock_bundle, monkeypatch):

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -112,6 +112,41 @@ def test_build_renders_workspace_tree_files(tmp_path, monkeypatch):
     assert staged.read_text() == '{"catalog": "prod_cat"}'
 
 
+def test_build_pipeline_no_orchestrator_skipped_with_warning(tmp_path, monkeypatch):
+    """A pipeline with no orchestrator produces no deployable resource, and
+    this is logged as a warning, not silently (issue #643)."""
+    import laktory.models.stacks.stack as stack_module
+
+    monkeypatch.setattr(settings, "build_root", str(tmp_path / "build"))
+
+    warnings = []
+    monkeypatch.setattr(stack_module.logger, "warning", warnings.append)
+
+    no_orch_stack = models.Stack(
+        name="no-orch-stack",
+        organization="o3",
+        environments={"dev": {}},
+        resources=models.StackResources(
+            pipelines={
+                "pl-no-orch": {
+                    "name": "pl-no-orch",
+                    "nodes": [
+                        {
+                            "name": "brz",
+                            "sources": [{"format": "JSON", "path": "/brz_source/"}],
+                            "sinks": [{"table_name": "brz"}],
+                        },
+                    ],
+                }
+            },
+        ),
+    )
+
+    no_orch_stack.build(env_name="dev")
+
+    assert any("pl-no-orch' has no orchestrator" in w for w in warnings)
+
+
 def test_stack_to_terraform_cli_vars_override_stack_var(monkeypatch, stack):
     # CLI vars must override stack-level variables (workflow_name defaults to UNDEFINED).
     monkeypatch.setenv("DATABRICKS_HOST", "mock-host")


### PR DESCRIPTION
Fixes #643

## Summary
- `laktory/AGENTS.md`'s DABs section claimed "Pipeline YAML does not need `orchestrator.type` — DABs creates the job automatically." Verified this is false: `laktory.dab.build_resources` silently skips (no resource, no error, only an easy-to-miss INFO log) any pipeline whose `orchestrator` is unset - it doesn't "create the job automatically." Reproduced directly: a pipeline YAML with no `orchestrator:` block run through `build_resources` produces zero pipelines/jobs.
- Found the same is true for the Terraform/Pulumi path (`Stack.build()`): an orchestrator-less pipeline is silently skipped there too, with no log message at all - confirming this isn't a DAB-specific quirk but a universal "no orchestrator = no deployable resource" rule, on either backend.
- Corrected the false claim in `laktory/AGENTS.md`. `docs/concepts/dab.md` (the actual docs site) already states this correctly, so no other doc needed a fix.
- Per discussion: a hard validation error requiring `orchestrator` would incorrectly break the legitimate case of a `Pipeline` that's only ever run locally/interactively (`pipeline.execute()`) and never deployed as IaC - so instead, upgraded the silent skip from `logger.info` (DAB) / no log at all (stack.py) to `logger.warning` in both `laktory/dab.py` and `laktory/models/stacks/stack.py`, so the skip is visible in build/deploy output on both backends.

## Test plan
- [x] `uv run pytest tests/test_dab.py tests/test_stack.py -q` - 54 passed, 1 skipped (pre-existing, missing `DATABRICKS_HOST`), including two new regression tests asserting a pipeline with no orchestrator produces zero resources and logs a warning naming it, on both the DAB and Terraform/Pulumi paths.
- [x] `ruff check` / `ruff format` on changed files (pre-commit hook applied one formatting wrap; pre-existing unrelated lint findings in `stack.py` confirmed present on `main` before this change).
- [x] Full suite (`uv run pytest -m "not databricks_connect" --cov=laktory tests`) - 949 passed, 77 skipped, 4 deselected, 4 xfailed. 1 failure: `test_data_quality_monitors.py::test_update_data_profiling_configs_skips_when_explicitly_unmanaged`, confirmed pre-existing/environment-only (missing Databricks credentials) and unrelated to this change.