### PR TITLE
Document the ${var.x} / ${vars.x} alias in AGENTS.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Fixed `DataFrameExpr` (SQL `expr:` pipeline nodes) splitting on a bare `;`, causing a `;` inside a `-- comment` to silently truncate/corrupt the query - `expr:` must now be a single SQL statement, enforced with a clear validation error instead of a confusing backend parse error. [[#640](https://github.com/okube-ai/laktory/issues/640)]
 * Fixed `laktory/AGENTS.md` incorrectly claiming a Pipeline YAML doesn't need `orchestrator.type` when deploying via DABs; a pipeline with no orchestrator is actually skipped entirely (no resource created, in both DABs and Terraform/Pulumi), now logged as a warning instead of an easy-to-miss INFO log. [[#643](https://github.com/okube-ai/laktory/issues/643)]
 ### Updated
-* n/a
+* Documented the `${var.x}` / `${vars.x}` alias in `laktory/AGENTS.md` (previously only on the docs site), and recommended `${var.x}` for pipeline YAML in DAB-integrated projects to match DAB's own native bundle-variable syntax. [[#642](https://github.com/okube-ai/laktory/issues/642)]
 ### Breaking changes
 * n/a
 

--- a/laktory/AGENTS.md
+++ b/laktory/AGENTS.md
@@ -56,6 +56,7 @@ All paths are relative to the current file. Variables can appear in paths:
 | Syntax | Description |
 |--------|-------------|
 | `${vars.name}` | String substitution; resolved at deploy time from stack variables |
+| `${var.name}` | Alias for `${vars.name}` — resolves identically; prefer it in DAB-integrated pipeline YAML (see DAB section) to match `databricks.yml`'s own bundle-variable syntax |
 | `${vars.NAME}` | Upper-case name reads from environment / system variables |
 | `${{ expr }}` | Python expression — evaluated at deploy time; supports conditionals |
 | `${resources.<key>.<prop>}` | Cross-reference another resource's runtime output (e.g. `.id`, `.name`) |
@@ -778,6 +779,7 @@ Key differences from Terraform:
 - Account-level resources (groups, metastore) still require Terraform
 - Pipeline YAML still needs `orchestrator.type` — DABs uses it to create the matching job/pipeline resource; a pipeline with no orchestrator is skipped silently (no error)
 - Use `databricks bundle deploy` instead of `laktory deploy`
+- Prefer `${var.x}` (singular) over `${vars.x}` in pipeline YAML — it resolves identically, but matches `databricks.yml`'s own native bundle-variable syntax, so you're not switching spellings between the two file types in the same project
 
 ---
 
@@ -827,6 +829,8 @@ isolation_mode: ${{ 'ISOLATED' if vars.env == 'prd' else 'OPEN' }}
 # Variables in file paths
 <<: !update ./overrides_${vars.env}.yaml
 ```
+
+`${var.x}` (singular) is an accepted alias for `${vars.x}` — both resolve identically.
 
 Cross-reference a resource's runtime output:
 ```yaml


### PR DESCRIPTION
Fixes #642

## Summary
- Confirmed `laktory/_parsers.py`'s regex (`\$\{vars?\.([a-zA-Z_][a-zA-Z0-9_]*)\}`) has always accepted both `${var.x}` and `${vars.x}` as synonyms, and this is already covered by an existing test (`tests/test_injectvars.py::test_var_syntax`, added incidentally alongside an unrelated fix in #628/#631) - so no code or test change is needed here, this is purely a documentation gap.
- `docs/concepts/variables.md` already documents the alias (`"The syntax is ${vars.VARIABLE_NAME} (or ${var.VARIABLE_NAME})"`), but `laktory/AGENTS.md` (the AI-agent-facing reference) never mentioned it and used `${vars.x}` exclusively in every example, while the maintainer's own reference implementation (`lakehouse-as-code/workflows-dab`) exclusively uses `${var.x}` - with nothing explaining that either works, or which to prefer.
- Documented the alias in `AGENTS.md`'s placeholder table and "Variable Injection" section, and added a recommendation to prefer `${var.x}` (singular) specifically for pipeline YAML in DAB-integrated projects, since it matches `databricks.yml`'s own native bundle-variable syntax - avoiding a spelling switch between the two file types in the same project.

## Test plan
- [x] `uv run pytest tests/test_injectvars.py -q` - 22 passed (unchanged; existing `test_var_syntax`/`test_settings_syntax` already cover the underlying alias behavior for both `var`/`vars` and `setting`/`settings`).
- [x] `ruff check` / `ruff format --check` on changed files.
- [x] Full suite (`uv run pytest -m "not databricks_connect" --cov=laktory tests`) - 949 passed, 77 skipped, 4 deselected, 4 xfailed. 1 failure: `test_data_quality_monitors.py::test_update_data_profiling_configs_skips_when_explicitly_unmanaged`, confirmed pre-existing/environment-only (missing Databricks credentials) and unrelated to this change.