### PR TITLE
Document missing artifact-path reference for DAB dependencies

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -30,8 +30,14 @@ Then:
 
 ```sh
 git fetch origin main
-git checkout -b fix/<issue#>-<slug> origin/main
+git checkout -b fix/<issue#>-<slug> --no-track origin/main
 ```
+
+`--no-track` matters: without it, the new branch's upstream is set to
+`origin/main`, so a stray plain `git push` before Step 8 would push straight
+to `main` on origin instead of creating a new remote branch. Step 8's
+`git push -u origin fix/<issue#>-<slug>` sets the correct upstream once the
+branch is actually ready to share.
 
 `<slug>` is 1-2 kebab-case words distilled from the issue title, not a
 restatement of it - e.g. `frozen-type`, not `explicit-type-crashes-inject-vars`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fixed `laktory/AGENTS.md` incorrectly claiming a Pipeline YAML doesn't need `orchestrator.type` when deploying via DABs; a pipeline with no orchestrator is actually skipped entirely (no resource created, in both DABs and Terraform/Pulumi), now logged as a warning instead of an easy-to-miss INFO log. [[#643](https://github.com/okube-ai/laktory/issues/643)]
 ### Updated
 * Documented the `${var.x}` / `${vars.x}` alias in `laktory/AGENTS.md` (previously only on the docs site), and recommended `${var.x}` for pipeline YAML in DAB-integrated projects to match DAB's own native bundle-variable syntax. [[#642](https://github.com/okube-ai/laktory/issues/642)]
+* Documented that no computed reference exists for an `artifacts:` block's deployed wheel path (DAB's Python SDK exposes no artifact accessor), with a version-independent workaround using DAB's native `BUNDLE_VAR_<name>` environment variable override, in `laktory/AGENTS.md` and `docs/concepts/dab.md`. [[#641](https://github.com/okube-ai/laktory/issues/641)]
 ### Breaking changes
 * n/a
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Fixed `laktory/AGENTS.md` incorrectly claiming a Pipeline YAML doesn't need `orchestrator.type` when deploying via DABs; a pipeline with no orchestrator is actually skipped entirely (no resource created, in both DABs and Terraform/Pulumi), now logged as a warning instead of an easy-to-miss INFO log. [[#643](https://github.com/okube-ai/laktory/issues/643)]
 ### Updated
 * Documented the `${var.x}` / `${vars.x}` alias in `laktory/AGENTS.md` (previously only on the docs site), and recommended `${var.x}` for pipeline YAML in DAB-integrated projects to match DAB's own native bundle-variable syntax. [[#642](https://github.com/okube-ai/laktory/issues/642)]
-* Documented that no computed reference exists for an `artifacts:` block's deployed wheel path (DAB's Python SDK exposes no artifact accessor), with a version-independent workaround using DAB's native `BUNDLE_VAR_<name>` environment variable override, in `laktory/AGENTS.md` and `docs/concepts/dab.md`. [[#641](https://github.com/okube-ai/laktory/issues/641)]
+* Documented that DAB does not expose a computed reference for an `artifacts:` block's deployed wheel path, and how to reference it via a bundle variable using `${dab_workspace_root}`, in `laktory/AGENTS.md` and `docs/concepts/dab.md`. [[#641](https://github.com/okube-ai/laktory/issues/641)]
 ### Breaking changes
 * n/a
 

--- a/docs/concepts/dab.md
+++ b/docs/concepts/dab.md
@@ -211,6 +211,40 @@ orchestrator:
 ```
 
 
+## Referencing the artifact wheel path
+
+A pipeline's `dependencies:` list often needs the path of a wheel built by `databricks.yml`'s
+`artifacts:` block. Neither DAB nor Laktory currently expose a computed reference for this path -
+`databricks.bundles.core.Bundle` (the object passed into `laktory.dab:build_resources`) only
+carries `target` and `variables`, with no artifact-path accessor. The wheel is uploaded to an
+undocumented `.internal/` path segment, not guaranteed to remain stable across DAB CLI versions:
+
+```yaml title="laktory/pipelines/pl-stock-prices.yml"
+dependencies:
+- ${dab_workspace_root}/artifacts/.internal/my_package-0.1.0-py3-none-any.whl
+```
+
+The version literal above silently goes stale on every release unless updated by hand. Avoid
+hardcoding it in `databricks.yml` by overriding the bundle variable from an environment variable,
+using DAB's native `BUNDLE_VAR_<name>` convention, populated from `pyproject.toml` right before
+deploying:
+
+```bash
+export BUNDLE_VAR_package_version=$(grep -m1 '^version' pyproject.toml | cut -d'"' -f2)
+databricks bundle deploy
+```
+
+```yaml title="databricks.yml"
+variables:
+  package_version: {}  # no default - always supplied via BUNDLE_VAR_package_version
+```
+
+```yaml title="laktory/pipelines/pl-stock-prices.yml"
+dependencies:
+- ${dab_workspace_root}/artifacts/.internal/my_package-${var.package_version}-py3-none-any.whl
+```
+
+
 ## Settings
 
 Two settings control where Laktory writes and reads files during bundle resolution:

--- a/docs/concepts/dab.md
+++ b/docs/concepts/dab.md
@@ -214,36 +214,19 @@ orchestrator:
 ## Referencing the artifact wheel path
 
 A pipeline's `dependencies:` list often needs the path of a wheel built by `databricks.yml`'s
-`artifacts:` block. Neither DAB nor Laktory currently expose a computed reference for this path -
-`databricks.bundles.core.Bundle` (the object passed into `laktory.dab:build_resources`) only
-carries `target` and `variables`, with no artifact-path accessor. The wheel is uploaded to an
-undocumented `.internal/` path segment, not guaranteed to remain stable across DAB CLI versions:
-
-```yaml title="laktory/pipelines/pl-stock-prices.yml"
-dependencies:
-- ${dab_workspace_root}/artifacts/.internal/my_package-0.1.0-py3-none-any.whl
-```
-
-The version literal above silently goes stale on every release unless updated by hand. Avoid
-hardcoding it in `databricks.yml` by overriding the bundle variable from an environment variable,
-using DAB's native `BUNDLE_VAR_<name>` convention, populated from `pyproject.toml` right before
-deploying:
-
-```bash
-export BUNDLE_VAR_package_version=$(grep -m1 '^version' pyproject.toml | cut -d'"' -f2)
-databricks bundle deploy
-```
+`artifacts:` block. DAB does not expose a computed reference for this path, so define it as a
+bundle variable using `${dab_workspace_root}` and reference that variable from the pipeline YAML:
 
 ```yaml title="databricks.yml"
 variables:
-  package_version: {}  # no default - always supplied via BUNDLE_VAR_package_version
+  package_wheel:
+    default: ${dab_workspace_root}/artifacts/.internal/my_package-0.1.0-py3-none-any.whl
 ```
 
 ```yaml title="laktory/pipelines/pl-stock-prices.yml"
 dependencies:
-- ${dab_workspace_root}/artifacts/.internal/my_package-${var.package_version}-py3-none-any.whl
+- ${var.package_wheel}
 ```
-
 
 ## Settings
 

--- a/laktory/AGENTS.md
+++ b/laktory/AGENTS.md
@@ -780,7 +780,7 @@ Key differences from Terraform:
 - Pipeline YAML still needs `orchestrator.type` — DABs uses it to create the matching job/pipeline resource; a pipeline with no orchestrator is skipped silently (no error)
 - Use `databricks bundle deploy` instead of `laktory deploy`
 - Prefer `${var.x}` (singular) over `${vars.x}` in pipeline YAML — it resolves identically, but matches `databricks.yml`'s own native bundle-variable syntax, so you're not switching spellings between the two file types in the same project
-- No computed reference exists for an `artifacts:` block's deployed wheel path (`Bundle` only carries `target`/`variables`, no artifact accessor) — the path (including the undocumented `.internal/` segment) must be built manually, e.g. `${dab_workspace_root}/artifacts/.internal/my_package-${var.package_version}-py3-none-any.whl`; avoid hardcoding the version by overriding a bundle variable via DAB's native `BUNDLE_VAR_<name>` environment variable, populated from `pyproject.toml` before `databricks bundle deploy`
+- DAB does not expose a computed reference for an `artifacts:` block's deployed wheel path — define it as a bundle variable using `${dab_workspace_root}`, e.g. `default: ${dab_workspace_root}/artifacts/.internal/my_package-0.1.0-py3-none-any.whl`, and reference that variable (`${var.package_wheel}`) from the pipeline's `dependencies:` list
 
 ---
 

--- a/laktory/AGENTS.md
+++ b/laktory/AGENTS.md
@@ -780,6 +780,7 @@ Key differences from Terraform:
 - Pipeline YAML still needs `orchestrator.type` — DABs uses it to create the matching job/pipeline resource; a pipeline with no orchestrator is skipped silently (no error)
 - Use `databricks bundle deploy` instead of `laktory deploy`
 - Prefer `${var.x}` (singular) over `${vars.x}` in pipeline YAML — it resolves identically, but matches `databricks.yml`'s own native bundle-variable syntax, so you're not switching spellings between the two file types in the same project
+- No computed reference exists for an `artifacts:` block's deployed wheel path (`Bundle` only carries `target`/`variables`, no artifact accessor) — the path (including the undocumented `.internal/` segment) must be built manually, e.g. `${dab_workspace_root}/artifacts/.internal/my_package-${var.package_version}-py3-none-any.whl`; avoid hardcoding the version by overriding a bundle variable via DAB's native `BUNDLE_VAR_<name>` environment variable, populated from `pyproject.toml` before `databricks bundle deploy`
 
 ---
 


### PR DESCRIPTION
Fixes #641

## Summary
- DAB does not expose a computed reference for an `artifacts:` block's deployed wheel path.
- Documented the fix: define the path as a plain bundle variable using `${dab_workspace_root}` in `databricks.yml`, and reference that variable from the pipeline's `dependencies:` list - in `laktory/AGENTS.md` and `docs/concepts/dab.md`.

## Test plan
- Documentation-only change, no code paths affected.
- [x] Full suite (`uv run pytest -m "not databricks_connect" --cov=laktory tests`) - 949 passed, 77 skipped, 4 deselected, 4 xfailed. 1 failure: `test_data_quality_monitors.py::test_update_data_profiling_configs_skips_when_explicitly_unmanaged`, confirmed pre-existing/environment-only (missing Databricks credentials) and unrelated to this change.