### PR TITLE
Document the DAB-context equivalent of settings.runtime_root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fixed `laktory/AGENTS.md` incorrectly claiming a Pipeline YAML doesn't need `orchestrator.type` when deploying via DABs; a pipeline with no orchestrator is actually skipped entirely (no resource created, in both DABs and Terraform/Pulumi), now logged as a warning instead of an easy-to-miss INFO log. [[#643](https://github.com/okube-ai/laktory/issues/643)]
 ### Updated
 * Documented the `${var.x}` / `${vars.x}` alias in `laktory/AGENTS.md` (previously only on the docs site), and recommended `${var.x}` for pipeline YAML in DAB-integrated projects to match DAB's own native bundle-variable syntax. [[#642](https://github.com/okube-ai/laktory/issues/642)]
+* Documented the DAB-context equivalent of `settings.runtime_root` (`root_path` on a pipeline, or the `LAKTORY_RUNTIME_ROOT` environment variable) for workspaces with public DBFS root access disabled, in `laktory/AGENTS.md` and `docs/concepts/dab.md`. [[#644](https://github.com/okube-ai/laktory/issues/644)]
 ### Breaking changes
 * n/a
 

--- a/docs/concepts/dab.md
+++ b/docs/concepts/dab.md
@@ -213,13 +213,14 @@ orchestrator:
 
 ## Settings
 
-Two settings control where Laktory writes and reads files during bundle resolution:
+These settings control where Laktory writes and reads files during bundle resolution:
 
 | Setting          | Environment variable     | Description                                                          |
 |------------------|--------------------------|----------------------------------------------------------------------|
 | `build_root`     | `LAKTORY_BUILD_ROOT`     | Local directory for generated config JSON files and the LDP notebook |
 | `workspace_root` | `LAKTORY_WORKSPACE_ROOT` | Workspace path where Laktory files are synced by DABs                |
+| `runtime_root`   | `LAKTORY_RUNTIME_ROOT`   | Root for streaming checkpoints; not auto-configured under DAB - set explicitly (e.g. to a Unity Catalog Volume path) if the default fails with `[DBFS_DISABLED]` |
 
-Both are auto-configured from the bundle context when left at their defaults. The `build_root` is set to 
+`build_root` and `workspace_root` are auto-configured from the bundle context when left at their defaults. The `build_root` is set to 
 `{bundle_root}/laktory/.build/` and `workspace_root` is derived as 
 `{dab_workspace_root}/files/laktory/.build/`. Explicit overrides via environment variables take priority. See [Laktory Settings](laktorysettings.md) for what each setting controls outside the DAB context.

--- a/laktory/AGENTS.md
+++ b/laktory/AGENTS.md
@@ -209,6 +209,7 @@ Stack
 | `ldp_template` | `str` | `DEFAULT` | Notebook template for Lakeflow Declarative Pipeline orchestrator |
 | `tags` | `list[str]` | `[]` | Tags for selective execution |
 | `comment` | `str` | `null` | Comment written to the associated table or view |
+| `root_path` | `str` | inherited from `Pipeline` | Root for this node's streaming checkpoints; overrides `Pipeline.root_path` |
 
 ---
 
@@ -780,6 +781,7 @@ Key differences from Terraform:
 - Pipeline YAML still needs `orchestrator.type` — DABs uses it to create the matching job/pipeline resource; a pipeline with no orchestrator is skipped silently (no error)
 - Use `databricks bundle deploy` instead of `laktory deploy`
 - Prefer `${var.x}` (singular) over `${vars.x}` in pipeline YAML — it resolves identically, but matches `databricks.yml`'s own native bundle-variable syntax, so you're not switching spellings between the two file types in the same project
+- Set `root_path: /Volumes/<catalog>/<schema>/<volume>/<path>` on a pipeline to replace what `settings.runtime_root` did stack-wide under Terraform — needed when the default checkpoint location fails with `[DBFS_DISABLED]`
 
 ---
 


### PR DESCRIPTION
Fixes #644

## Summary
- Confirmed `Pipeline.root_path_` / `PipelineNode.root_path_` work as a per-pipeline override for streaming-checkpoint roots, and `settings.runtime_root` reads `LAKTORY_RUNTIME_ROOT` the same way `build_root`/`workspace_root` already do under DAB - but unlike those two, it isn't auto-configured by `laktory.dab:build_resources`, and neither escape hatch was documented anywhere (unlike `dataframe_api`, which has a documented per-pipeline equivalent).
- Without an override, streaming sinks fall back to a DBFS-rooted default checkpoint location, which fails with `[DBFS_DISABLED]` in workspaces with public DBFS root access disabled.
- Documented `root_path` in `laktory/AGENTS.md`'s DAB section and `PipelineNode` field table, and added `runtime_root`/`LAKTORY_RUNTIME_ROOT` to `docs/concepts/dab.md`'s Settings table.

## Test plan
- Documentation-only change, no code paths affected.
- [x] Full suite (`uv run pytest -m "not databricks_connect" --cov=laktory tests`) - 949 passed, 77 skipped, 4 deselected, 4 xfailed. 1 failure: `test_data_quality_monitors.py::test_update_data_profiling_configs_skips_when_explicitly_unmanaged`, confirmed pre-existing/environment-only (missing Databricks credentials) and unrelated to this change.