### PR TITLE
Document the local-debugging pattern (Databricks Connect + pl.execute)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Documented the `${var.x}` / `${vars.x}` alias in `laktory/AGENTS.md` (previously only on the docs site), and recommended `${var.x}` for pipeline YAML in DAB-integrated projects to match DAB's own native bundle-variable syntax. [[#642](https://github.com/okube-ai/laktory/issues/642)]
 * Documented that DAB does not expose a computed reference for an `artifacts:` block's deployed wheel path, and how to reference it via a bundle variable using `${dab_workspace_root}`, in `laktory/AGENTS.md` and `docs/concepts/dab.md`. [[#641](https://github.com/okube-ai/laktory/issues/641)]
 * Documented the DAB-context equivalent of `settings.runtime_root` (`root_path` on a pipeline, or the `LAKTORY_RUNTIME_ROOT` environment variable) for workspaces with public DBFS root access disabled, in `laktory/AGENTS.md` and `docs/concepts/dab.md`. [[#644](https://github.com/okube-ai/laktory/issues/644)]
+* Documented the local-debugging pattern (Databricks Connect + `pl.execute(write_sinks=False, selects=[...])`) - including the `write_sinks` write-safety caveat, the `as_stream` inspection limitation, and the shared-checkpoint-with-production footgun - in `docs/concepts/pipeline.md` and `laktory/AGENTS.md`. [[#645](https://github.com/okube-ai/laktory/issues/645)]
 ### Breaking changes
 * n/a
 

--- a/docs/concepts/pipeline.md
+++ b/docs/concepts/pipeline.md
@@ -228,7 +228,8 @@ FROM
 ```
 </div>
 
-### Spark
+#### Spark session
+
 If you select `PYSPARK` as the DataFrame backend, Laktory will instantiate 
 a default Spark Session, but you can register your own instead. This works using a 
 local, a Databricks notebook or Databricks connect Spark Session:
@@ -241,7 +242,7 @@ spark = DatabricksSession.builder.getOrCreate()
 register_spark_session(spark)
 ```
 
-### Debugging a single node
+#### Debugging a single node
 
 Combine a live Databricks Connect session (above) with `write_sinks=False` and `selects` to validate
 a node's transform logic in seconds, without deploying anything. This is a much faster iteration loop

--- a/docs/concepts/pipeline.md
+++ b/docs/concepts/pipeline.md
@@ -241,6 +241,49 @@ spark = DatabricksSession.builder.getOrCreate()
 register_spark_session(spark)
 ```
 
+### Debugging a single node
+
+Combine a live Databricks Connect session (above) with `write_sinks=False` and `selects` to validate
+a node's transform logic in seconds, without deploying anything. This is a much faster iteration loop
+than a full deploy + run cycle, and should be the first thing you reach for when a node's SQL or
+DataFrame logic is failing - reserve deploy + run for verifying job/task orchestration and
+streaming/checkpoint behavior end-to-end.
+
+```py title="debug.py"
+from databricks.connect import DatabricksSession
+from laktory import models, register_spark_session
+
+spark = DatabricksSession.builder.profile("<profile>").getOrCreate()  # or .getOrCreate() for serverless
+register_spark_session(spark)
+
+with open("laktory/pipelines/pl-stock-prices.yml") as fp:
+    pl = models.Pipeline.model_validate_yaml(fp)
+pl = pl.inject_vars(vars={"catalog": "dev"})  # under DAB, use bundle_vars instead - see the DAB integration guide
+
+pl.execute(write_sinks=False)                                 # run every node first
+# pl.execute(write_sinks=False, selects=["brz_stock_prices"])  # then narrow down to the failing node
+
+df = pl.nodes_dict["brz_stock_prices"].output_df.to_native()
+df.show()
+```
+
+`selects` accepts `node_name` (that node only), `*node_name` (with upstream dependencies),
+`node_name*` (with downstream dependencies), or `*node_name*` (both).
+
+A few things to know before relying on this:
+
+- **`write_sinks` is real.** `False` only reads sources and runs transformations - nothing is written
+  anywhere. `True` writes to whatever catalog/schema/table the injected variables resolve to, which is
+  useful for an end-to-end check but is a real write against that environment, not a dry run.
+- **A streaming source can't be inspected directly.** When a source has `as_stream: true`, `output_df`
+  is a genuine Spark streaming DataFrame and cannot be `.show()`n or collected. To inspect it, override
+  the source to a static read for the debug session: `pl.nodes_dict["x"].sources[0].as_stream = False`.
+- **Checkpoints are shared with production.** A sink's `checkpoint_path` defaults to
+  `{root_path}/checkpoints/sink-{uuid}` - a deterministic path based on pipeline/node identity, the same
+  one the deployed job uses. Running `write_sinks=True` on a streaming node without first pointing
+  `root_path` (or the sink's `checkpoint_path`) at a separate scratch location will advance the real
+  checkpoint, and the production job will skip data on its next run believing it was already processed.
+
 ### Orchestrators
 While local execution is ideal for small datasets or prototyping, orchestrators unlock more advanced features such as 
 parallel processing, automatic schema management, and historical re-processing. The desired orchestrator can be 

--- a/laktory/AGENTS.md
+++ b/laktory/AGENTS.md
@@ -786,6 +786,35 @@ Key differences from Terraform:
 
 ---
 
+## Local Development & Debugging
+
+Prefer this over a full deploy+run cycle as the *first* debugging step for transform-logic issues
+(SQL errors, bad column mappings, type casts) — it's much faster and touches nothing deployed.
+Reserve deploy+run for verifying job/task orchestration and streaming/checkpoint behavior end-to-end.
+
+```python
+from databricks.connect import DatabricksSession
+from laktory import models, register_spark_session
+
+spark = DatabricksSession.builder.profile("<profile>").getOrCreate()  # or .getOrCreate() for serverless
+register_spark_session(spark)
+
+with open("laktory/pipelines/pl-stock-prices.yml") as fp:
+    pl = models.Pipeline.model_validate_yaml(fp)
+pl = pl.inject_vars(vars={"catalog": "dev"})  # DAB: use bundle_vars instead
+
+pl.execute(write_sinks=False)                                 # run every node first
+# pl.execute(write_sinks=False, selects=["brz_stock_prices"])  # then narrow to the failing node
+df = pl.nodes_dict["brz_stock_prices"].output_df.to_native()
+```
+
+- `write_sinks=False` only reads + transforms, nothing is written; `True` writes to the real target from the injected variables — not a dry run
+- A node with `as_stream: true` returns a genuine streaming DataFrame that can't be inspected directly — override `pl.nodes_dict["x"].sources[0].as_stream = False` to debug it as a static read
+- `checkpoint_path` defaults to `{root_path}/checkpoints/sink-{uuid}`, the *same* path the deployed job uses — `write_sinks=True` on a streaming node without pointing `root_path` elsewhere first will advance the real checkpoint and cause the production job to skip data
+- Full guide, including `selects` syntax - see the `Pipeline` docs page's "Debugging a single node" section
+
+---
+
 ## Naming Conventions
 
 | Element | Convention | Example |


### PR DESCRIPTION
Fixes #645

## Summary
- `AGENTS.md` covered YAML structure and the DAB deployment path in detail, but never mentioned that a pipeline node can be executed locally against a live Databricks Connect session without deploying anything - a much faster loop than a full deploy+run cycle for iterating on transform logic.
- Verified `pl.execute(write_sinks=False, selects=[...])` and `pl.nodes_dict[x].output_df` work exactly as described, end-to-end, locally.
- Verified three safety-relevant details in code before documenting them, per discussion:
  - `write_sinks=True` is a real write against whatever the injected variables resolve to, not a dry run.
  - A node with `as_stream: true` produces a genuine Spark streaming DataFrame that can't be inspected via `.show()`/`.collect()` - it must be overridden to a static read to debug locally.
  - A sink's `checkpoint_path` defaults to a path derived purely from pipeline/node identity (`root_path/checkpoints/sink-{uuid}`), the same path the deployed job uses - so `write_sinks=True` on a streaming node without first isolating `root_path` shares (and can silently advance) production's checkpoint state.
- Added the full guide with these caveats to `docs/concepts/pipeline.md`'s Execution section, and a terser pointer + example to `laktory/AGENTS.md`.
- Considered exposing this via an MCP tool instead of a plain doc/script pattern; deferred as a separate, bigger feature (live session/credential management, different risk class) rather than folding it into this docs-only fix.

## Test plan
- Documentation-only change, no code paths affected. Both code snippets in the docs were run end-to-end locally (local Spark session standing in for Databricks Connect) to confirm they work exactly as written, including the `as_stream` override mutation.
- [ ] Full suite (`make test`) - pending, will report result.